### PR TITLE
using v7_relativeSplatPaths

### DIFF
--- a/.github/workflows/react-tests.yml
+++ b/.github/workflows/react-tests.yml
@@ -32,7 +32,7 @@ jobs:
         docker compose -f BuildTools/docker-compose.yml up -d --build --remove-orphans frontend
     - name: Test with Jest
       run: |
-        docker exec stocks_frontend /bin/bash -c 'cd src; npm test -- --coverage' > jest.results.log 2>&1
+        docker exec stocks_frontend /bin/bash -c 'cd src; npm test -- --detectOpenHandles' > jest.results.log 2>&1
       continue-on-error: true
     - name: Output Results
       run: |

--- a/BuildTools/docker-compose.yml
+++ b/BuildTools/docker-compose.yml
@@ -71,6 +71,11 @@ services:
       - "8889:80"
     expose:
       - 8889
+    # healthcheck:
+    #   test: ["CMD", "curl", "--fail", "http://localhost:80/health/status"]
+    #   interval: 5s
+    #   timeout: 10s
+    #   retries: 10
     restart: unless-stopped
     volumes:
       - ../django:/app/

--- a/BuildTools/docker-compose.yml
+++ b/BuildTools/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 name: stockapp
 services:
   stocksdb:
@@ -78,6 +76,7 @@ services:
       - ../django:/app/
     networks:
       - private
+      - public
   frontend:
     container_name: stocks_frontend
     image: stocks_frontend
@@ -94,6 +93,7 @@ services:
       - ../reactjs/public:/react-app/public/
     networks:
       - public
+      - private
     environment:
       - CHOKIDAR_USEPOLLING=true
       - CHOKIDAR INTERVAL=500 # Decrease CPU usage by checking every 500ms

--- a/django/backend/settings.py
+++ b/django/backend/settings.py
@@ -27,7 +27,7 @@ SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = bool(os.environ.get("DEBUG", default=0))
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 # Application definition
 

--- a/reactjs/jest.config.ts
+++ b/reactjs/jest.config.ts
@@ -9,8 +9,11 @@ const config: Config = {
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   testMatch: ['**/__tests__/**/*.test.(ts|tsx)', '**/?(*.)+(spec|test).(ts|tsx)'],
+  collectCoverage: true,
+  testTimeout: 30000,
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
   reporters: [
+    'default',
     ['jest-slow-test-reporter', {
       numTests: 8,
       warnOnSlowerThan: 300,

--- a/reactjs/src/App.tsx
+++ b/reactjs/src/App.tsx
@@ -19,7 +19,6 @@ export default function App() {
   }), {
     future: {
       v7_relativeSplatPath: true,
-      v7_startTransition: true,
     },
   });
   

--- a/reactjs/src/__tests__/App.test.tsx
+++ b/reactjs/src/__tests__/App.test.tsx
@@ -1,39 +1,5 @@
-import '@testing-library/jest-dom';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { RouterProvider } from 'react-router';
-import { createMemoryRouter } from 'react-router-dom';
-import getRoutes from '../Routes';
-import { sitedetails, get_auth_header, get_user_from_cookie, refresh_session } from '../utils/appContext';
-
-// suppressing v7 transition messages
-beforeAll(() => {
-  jest.spyOn(console, 'warn').mockImplementation((msg) => {
-    if (
-      typeof msg === 'string' &&
-      msg.includes('React Router Future Flag Warning')
-    ) return;
-    console.warn(msg);
-  });
-});
-
-const renderWithRoute = async (route: string) => {
-  const testRouter = createMemoryRouter(
-    getRoutes({
-      sitedetails,
-      get_auth_header,
-      get_user_from_cookie,
-      refresh_session,
-    }),
-     {
-    initialEntries: [route],
-  })
-  render(
-    <RouterProvider router={testRouter} />
-  );
-  await waitFor(() => {
-    expect(screen.getByTestId('site-footer')).toBeInTheDocument();
-  }, { timeout: 5000 });
-};
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithRoute } from './utils/testRouter';
 
 test('base', () => {
   expect(true).toBeTruthy();
@@ -57,7 +23,7 @@ describe("App", () => {
 
   test('navigate to login page from home', async () => {
     await renderWithRoute('/');
-    const loginLink = await screen.getByText(/Login/i);
+    const loginLink = screen.getByText(/Login/i);
     fireEvent.click(loginLink);
     await waitFor(() => {
       expect(screen.getByText('Account Login')).toBeInTheDocument()

--- a/reactjs/src/__tests__/utils/testRouter.tsx
+++ b/reactjs/src/__tests__/utils/testRouter.tsx
@@ -1,0 +1,35 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { RouterProvider } from 'react-router';
+import { createMemoryRouter } from 'react-router-dom';
+import getRoutes from '../../Routes';
+import { sitedetails, get_auth_header, get_user_from_cookie, refresh_session } from '../../utils/appContext';
+
+sitedetails.django_url = 'http://backend:80';
+
+export const createTestRouter = (route: string) =>
+    createMemoryRouter(
+        getRoutes({
+        sitedetails,
+        get_auth_header,
+        get_user_from_cookie,
+        refresh_session,
+        }),
+        {
+            initialEntries: [route],
+            future: {
+                v7_relativeSplatPath: true,
+            }
+        }
+    );
+
+export const renderWithRoute = async (route: string) => {
+  const testRouter = createTestRouter(route);
+  render(
+    <RouterProvider router={testRouter} />
+  );
+  await waitFor(() => {
+    expect(screen.getByTestId('site-footer')).toBeInTheDocument();
+  }, { timeout: 5000 });
+
+  return testRouter;
+};

--- a/reactjs/src/components/Auth.jsx
+++ b/reactjs/src/components/Auth.jsx
@@ -5,6 +5,7 @@ import RegisterForm from "./auth/RegisterForm";
 import axios from 'axios';
 import { useNavigate } from 'react-router';
 import Cookies from 'universal-cookie';
+import { sitedetails } from "../utils/appContext";
 
 const cookies = new Cookies(null, { path: '/' });
 
@@ -16,16 +17,14 @@ export function LoginRegister({ mode }) {
   const [errorMessage, setErrorMessage] = useState(""); // State to manage error message
   const navigate = useNavigate(); // Access the history object for navigation
 
-  const base_url = 'http://localhost:8889'; // Define your base URL here
-
   const handleSubmit = async (e, isLoginPage) => {
     e.preventDefault();
     try {
       let url = '';
       if (isLoginPage) {
-        url = `${base_url}/auth/login/`;
+        url = `${sitedetails.django_url}/auth/login/`;
       } else {
-        url = `${base_url}/auth/register/`;
+        url = `${sitedetails.django_url}/auth/register/`;
       }
       const response = await axios.post(url, formData);
       if (response.status === 200 || response.status === 201) {

--- a/reactjs/src/components/stocks/Show_ticker_news.jsx
+++ b/reactjs/src/components/stocks/Show_ticker_news.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import axios from 'axios';
 import Spinner from 'react-bootstrap/Spinner';
 import { useParams } from 'react-router';
+import { sitedetails } from '../../utils/appContext';
 
 function withParams(Component){
   const ComponentWithParams = (props) => <Component {...props} params={useParams()} />;
@@ -26,7 +27,7 @@ class ShowTickerNews extends React.Component {
   componentDidMount() {
     let { ticker } = this.props.params
     this.setState({symbol: ticker})
-    let url = 'http://localhost:8889/stocks/get_ticker_news/?ticker=' + ticker    
+    let url = sitedetails.django_url + '/stocks/get_ticker_news/?ticker=' + ticker    
     axios.get(url)
       .then(res => {
           //console.log(res.data); // Log the response data to understand its structure

--- a/reactjs/src/components/stocks/findstock.jsx
+++ b/reactjs/src/components/stocks/findstock.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import axios from 'axios';
 import Spinner from 'react-bootstrap/Spinner'
+import { sitedetails } from '../../utils/appContext';
 
 
 class FindStock extends React.Component {
@@ -14,7 +15,7 @@ class FindStock extends React.Component {
   search = async val => {
     this.setState({ loading: true});
     axios.get(
-      'http://localhost:8889/stocks/find_ticker/?ticker=' + val
+      sitedetails.django_url + '/stocks/find_ticker/?ticker=' + val
     ).then(res => {
       this.setState({stocks: res.data['records'], loading: false})
     }).catch(error => {

--- a/reactjs/src/components/stocks/show_ticker.jsx
+++ b/reactjs/src/components/stocks/show_ticker.jsx
@@ -6,6 +6,8 @@ import { useParams } from 'react-router';
 import Highcharts from 'highcharts'
 import HighchartsReact from 'highcharts-react-official'
 
+import { sitedetails } from '../../utils/appContext';
+
 function withParams(Component){
   const ComponentWithParams = (props) => <Component {...props} params={useParams()} />;
 
@@ -33,7 +35,7 @@ class ShowTickerChart extends React.Component {
     const now = new Date()
     const current_time = (now.getTime() / 1000).toString().split('.')[0]
     const four_months_ago = (new Date(now.getFullYear(), now.getMonth() - 4, now.getDate()).getTime() / 1000).toString().split('.')[0]; // Date four months ago
-    let url = 'http://localhost:8889/stocks/get_ticker_metrics/?ticker=' + ticker + '&interval=1d&starttime=' + four_months_ago + '&endtime=' + current_time
+    let url = sitedetails.django_url + '/stocks/get_ticker_metrics/?ticker=' + ticker + '&interval=1d&starttime=' + four_months_ago + '&endtime=' + current_time
     //https://query1.finance.yahoo.com/v8/finance/chart/AMZN?interval=1d&includePrePost=True&period1=1704174096&period2=1714542096&lang=en-Us&region=US
     axios.get(url)
       .then(res => {

--- a/reactjs/src/setupTests.ts
+++ b/reactjs/src/setupTests.ts
@@ -4,3 +4,14 @@
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
 import 'whatwg-fetch';
+
+// suppressing v7 transition messages
+beforeAll(() => {
+  jest.spyOn(console, 'warn').mockImplementation((msg) => {
+    if (
+      typeof msg === 'string' &&
+      msg.includes('React Router Future Flag Warning')
+    ) return;
+    console.warn(msg);
+  });
+});

--- a/reactjs/src/setupTests.ts
+++ b/reactjs/src/setupTests.ts
@@ -14,4 +14,16 @@ beforeAll(() => {
     ) return;
     console.warn(msg);
   });
+  // Suppress ECONNREFUSED errors (e.g., API not running during tests)
+  jest.spyOn(console, 'error').mockImplementation((msg) => {
+    if (
+      typeof msg === 'string' &&
+      (
+        msg.includes('connect ECONNREFUSED') || 
+        msg.includes('getaddrinfo ENOTFOUND') // this happens when the backend container isn't up yet
+      )
+    ) return;
+    // Otherwise, show error
+    console.error(msg);
+  });
 });

--- a/reactjs/src/setupTests.ts
+++ b/reactjs/src/setupTests.ts
@@ -5,6 +5,9 @@
 import '@testing-library/jest-dom';
 import 'whatwg-fetch';
 
+const originalWarn = console.warn;
+const originalError = console.error;
+
 // suppressing v7 transition messages
 beforeAll(() => {
   jest.spyOn(console, 'warn').mockImplementation((msg) => {
@@ -12,7 +15,7 @@ beforeAll(() => {
       typeof msg === 'string' &&
       msg.includes('React Router Future Flag Warning')
     ) return;
-    console.warn(msg);
+    originalWarn(msg);
   });
   // Suppress ECONNREFUSED errors (e.g., API not running during tests)
   jest.spyOn(console, 'error').mockImplementation((msg) => {
@@ -24,6 +27,6 @@ beforeAll(() => {
       )
     ) return;
     // Otherwise, show error
-    console.error(msg);
+    originalError(msg);
   });
 });

--- a/reactjs/src/utils/appContext.ts
+++ b/reactjs/src/utils/appContext.ts
@@ -6,7 +6,7 @@ const cookies = new Cookies(null, { path: '/' });
 export const sitedetails = {
     sitename: 'Stock Strategies',
     tagline: 'Test Trading Strategies',
-    django_url: 'http://localhost:8889',
+    django_url: 'http://127.0.0.1:8889',
 };
 
 export function get_auth_header() {


### PR DESCRIPTION
addresses #311 
updating jest config to use coverage, and timeout of 30s
opening the network for frontend/backend so the unit tests work between react and django
adding all hosts to allowed_hosts in django
refactoring to have setupTests ignore React warnings
refactoring to have the testRouter in a utils file
replacing hard coded references to the django api to use sitedetails